### PR TITLE
Add an option to parse more leniently

### DIFF
--- a/src/main/scala/com/github/seratch/ltsv4s/LTSV.scala
+++ b/src/main/scala/com/github/seratch/ltsv4s/LTSV.scala
@@ -2,9 +2,11 @@ package com.github.seratch.ltsv4s
 
 object LTSV {
 
-  def parseLine(line: String): Map[String, String] = LTSVParser.parse(line).head
+  def parseLine(line: String, lenient: Boolean = false): Map[String, String] = 
+    LTSVParser.parse(line, lenient).head
 
-  def parseLines(lines: String): List[Map[String, String]] = LTSVParser.parse(lines)
+  def parseLines(lines: String, lenient: Boolean = false): List[Map[String, String]] = 
+    LTSVParser.parse(lines, lenient)
 
   def dump(value: Map[String, String]): String = {
     value.map { case (k, v) => k + ":" + v }.mkString("\t")

--- a/src/main/scala/com/github/seratch/ltsv4s/LTSVParser.scala
+++ b/src/main/scala/com/github/seratch/ltsv4s/LTSVParser.scala
@@ -16,7 +16,14 @@ fbyte = %x01-08 / %x0B / %x0C / %x0E-FF
 */
 import scala.util.parsing.combinator.RegexParsers
 
-object LTSVParser extends RegexParsers {
+/**
+ * Parser configuration
+ * 
+ * @param lenient Allow a wider range of characters in field values than the LTSV spec
+ */
+case class LTSVParserConfig(lenient: Boolean = false)
+
+class LTSVParser(config: LTSVParserConfig) extends RegexParsers {
 
   override def skipWhitespace = false
 
@@ -24,7 +31,11 @@ object LTSVParser extends RegexParsers {
   def record = repsep(field, tab) ^^ { _.toMap }
   def field = label ~ ":" ~ fieldValue ^^ { case k ~ ":" ~ v => (k, v) }
   def label = "[0-9A-Za-z_\\.-]+".r
-  def fieldValue = """[\u000B\u000C\u0001-\u0008\u000E-\u00FF]*""".r
+  def fieldValue = 
+    if (config.lenient)
+      """[^\t\r\n]*""".r
+    else
+      """[\u000B\u000C\u0001-\u0008\u000E-\u00FF]*""".r
   def tab = '\t'
   def nl = opt('\r') <~ '\n'
 
@@ -35,3 +46,7 @@ object LTSVParser extends RegexParsers {
 
 }
 
+object LTSVParser {
+  def parse(input: String, lenient: Boolean = false): List[Map[String, String]] = 
+    new LTSVParser(LTSVParserConfig(lenient)).parse(input)
+}

--- a/src/test/scala/com/github/seratch/ltsv4s/LTSVSpec.scala
+++ b/src/test/scala/com/github/seratch/ltsv4s/LTSVSpec.scala
@@ -45,4 +45,17 @@ class LTSVSpec extends FlatSpec with ShouldMatchers {
     }
   }
 
+  it should "fail to parse invalid LTSV if in strict mode" in {
+    intercept[IllegalArgumentException] {
+      LTSV.parseLine("name:クリス\tage:28")
+    }
+  }
+
+  it should "allow invalid LTSV if in lenient mode" in {
+    val ltsv: Map[String, String] = LTSV.parseLine("name:クリス\tage:28", lenient=true)
+    ltsv.size should equal(2)
+    ltsv("name") should equal("クリス")
+  }
+
+
 }


### PR DESCRIPTION
In lenient mode, the parser will allow any character in a field value, apart from tab and newline chars.

Useful for idiots like me who have generated invalid LTSV data and want to parse it.

All new method parameters have a default value, so the API is backwards compatible.
By default the parser runs in strict mode.
