### PR TITLE
Apply Scala3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,21 +6,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.3.0
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+        uses: actions/setup-java@v3
         with:
-          java-version: openjdk@1.17.0
+          distribution: temurin
+          java-version: 17
+          cache: sbt
       - name: Check scalafmtCheck
-        run: sbt scalafmtCheckAll scalafmtSbtCheck
+        run: sbt scalafmtCheckAll Test/scalafmtCheckAll scalafmtSbtCheck
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.3.0
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v13
+        uses: actions/setup-java@v3
         with:
-          java-version: openjdk@1.17.0
+          distribution: temurin
+          java-version: 17
+          cache: sbt
       - name: Tests
-        run: sbt clean coverage +test
+        run: sbt clean coverage +test; sbt coverageReport
+      - name: Archive coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: scoverage-report
+          path: target/scala-3.2.2/scoverage-report

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.5.2
+version = 3.7.1
 preset = IntelliJ
-runner.dialect = scala213
+runner.dialect = scala3

--- a/build.sbt
+++ b/build.sbt
@@ -8,15 +8,15 @@ lazy val root =
     )
     .settings(
       // compiler
-      scalaVersion := "2.13.8",
+      scalaVersion := "3.2.2",
       scalacOptions ++= Seq("-deprecation", "-unchecked"),
-      crossScalaVersions := Seq("2.13.8", "2.12.15")
+      crossScalaVersions := Seq("3.2.2", "2.13.10", "2.12.17")
     )
     .settings(
       // dependencies
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1",
-        "org.scalatest" %% "scalatest" % "3.2.11" % Test
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "2.2.0",
+        "org.scalatest" %% "scalatest" % "3.2.15" % Test
       )
     )
 
@@ -24,7 +24,7 @@ val _pomExtra = <url>https://github.com/seratch/ltsv4s/</url>
     <licenses>
       <license>
         <name>Apache License, Version 2.0</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         <distribution>repo</distribution>
       </license>
     </licenses>
@@ -36,6 +36,6 @@ val _pomExtra = <url>https://github.com/seratch/ltsv4s/</url>
       <developer>
         <id>seratch</id>
         <name>Kazuhiro Sera</name>
-        <url>https://git.io/sera</url>
+        <url>https://github.com/seratch</url>
       </developer>
     </developers>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.12")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.17")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 ThisBuild / versionScheme := Some("early-semver")
-ThisBuild / version := "1.0.4"
+ThisBuild / version := "1.0.5"


### PR DESCRIPTION
# 概要

Scala 3 に対応しました

# 詳細

- クロスバージョンに Scala 3.2.2 を追加
- pom に記載された一部のURLを変更（https やリダイレクト先に変更）
- GHActionでテストコードのフォーマットチェックをするようにした
- GHActionでカバレッジをアーカイブするようにした
- 各種ライブラリのバージョンアップ

| ライブラリ | 旧バージョン | 新バージョン | 備考 |
|----|----|----|----|
| scala | 2.13.8, 2.12.15 | 3.2.2, 2.13.10, 2.12.17 | Scala3を追加 |
| sbt | 1.6.2 | 1.8.2 | |
| sbt-scoverage | 1.9.3 | 2.0.7 | |
| sbt-scalafmt | 2.4.6 | 2.5.0 | |
| scalafmt-core | 3.5.2 | 3.7.1 | |
| sbt-pgp | 2.0.1 | 2.2.1 | |
| scala-parser-combinators | 2.1.1 | 2.2.0 | |
| scalatest | 3.2.11 | 3.2.15 | |
| actions/checkout | 3.0.2 | 3.3.0 | |
